### PR TITLE
Add wrapper around curl to make requests safely

### DIFF
--- a/bin/download
+++ b/bin/download
@@ -4,6 +4,11 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+plugin_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=../lib/utils.bash
+source "${plugin_dir}/../lib/utils.bash"
+
 declare -r JQ_REPO="https://github.com/stedolan/jq.git"
 declare -r RELEASES_URL="https://api.github.com/repos/stedolan/jq/releases"
 
@@ -40,9 +45,9 @@ get_assets_url() {
   declare install_version="$1"
 
   if [ -n "${GITHUB_API_TOKEN:+defined}" ]; then
-    declare releases_json="$(curl -s "$RELEASES_URL" -H "Authorization: token $GITHUB_API_TOKEN")"
+    declare releases_json="$(curl_wrapper -fsS "$RELEASES_URL" -H "Authorization: token $GITHUB_API_TOKEN")"
   else
-    declare releases_json="$(curl -s "$RELEASES_URL")"
+    declare releases_json="$(curl_wrapper -fsS "$RELEASES_URL")"
   fi
 
   declare -a asset_urls
@@ -69,9 +74,9 @@ find_all_asset_names() {
   fi
 
   if [ -n "${GITHUB_API_TOKEN:+defined}" ]; then
-    declare assets_json="$(curl -s "$assets_url" -H "Authorization: token $GITHUB_API_TOKEN")"
+    declare assets_json="$(curl_wrapper -fsS "$assets_url" -H "Authorization: token $GITHUB_API_TOKEN")"
   else
-    declare assets_json="$(curl -s "$assets_url")"
+    declare assets_json="$(curl_wrapper -fsS "$assets_url")"
   fi
   declare -a output=($(echo "$assets_json" | sed -n -E 's/[[:blank:]]*"browser_download_url":[[:blank:]]{0,2}"([^"]{8,})"/\1/p'))
   echo "${output[@]}"
@@ -127,7 +132,7 @@ download() {
       error_exit "Malformed URL"
     fi
     mkdir "$download_path/bin"
-    curl -fL -o "$download_path/bin/jq" "$download_url"
+    curl_wrapper -fsS -L -o "${download_path}/bin/jq" "$download_url"
   else
     rm -rf "$download_path"
     git init "$download_path"

--- a/bin/list-all
+++ b/bin/list-all
@@ -7,6 +7,11 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+plugin_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=../lib/utils.bash
+source "${plugin_dir}/../lib/utils.bash"
+
 readonly RELEASES_URL="https://api.github.com/repos/stedolan/jq/releases"
 
 # https://github.com/rbenv/ruby-build/blob/ac92ec0507fad718e7abcf13540641937ecfef3f/bin/ruby-build#L1201
@@ -17,9 +22,9 @@ sort_versions() {
 
 list_versions() {
   if [ -n "${GITHUB_API_TOKEN:+defined}" ]; then
-    declare releases="$(curl -fsS --url $RELEASES_URL -H "Authorization: token $GITHUB_API_TOKEN")"
+    declare releases="$(curl_wrapper -fsS "$RELEASES_URL" -H "Authorization: token $GITHUB_API_TOKEN")"
   else
-    declare releases="$(curl -fsS --url $RELEASES_URL)"
+    declare releases="$(curl_wrapper -fsS "$RELEASES_URL")"
   fi
   echo "$(echo "$releases" | grep -oE "tag_name\": *\".*\"," | sed 's/tag_name\": *\"//;s/\",//')"
 }

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Wrap curl to ensure that the "User-Agent" header is always set to a value
+# that ensures detection of curl as the client making the request.  This
+# overrides the value of the `user-agent` setting in the `.curlrc` file.
+#
+# N.B. The actual curl version is of no importance; also GitHub caches HTTP
+# responses for some small amount of time, please bare this in mind.
+curl_wrapper() {
+  curl -A 'curl/1.0.0' -H 'Accept: application/json' "$@"
+}


### PR DESCRIPTION
The user agent that curl uses when making requests can be overridden using using the "user-agent" setting in the `.curlrc` file, and setting a custom user agent might break asdf-jq as it relies on a pretty-printed JSON document to be returned when querying GitHub API for the list of known releases.

GitHub API will only return a pretty-printed JSON document in the response to a request made by curl (or any other client that uses the same User-Agent header); otherwise, and for any other client, the JSON document sent back will be minified (machine parsable).

Thus, ensure that requests asdf-jq makes always set the correct User-Agent header, overriding any local or system-wide setting.

Signed-off-by: Krzysztof Wilczyński <kw@linux.com>