### PR TITLE
Fix upstream jq repo reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![](https://github.com/AZMCode/asdf-jq/workflows/ci/badge.svg)
 
-[jq](https://stedolan.github.io/jq/) plugin for the [asdf](https://github.com/asdf-vm/asdf) version manager.
+[jq](https://jqlang.github.io/jq/) plugin for the [asdf](https://github.com/asdf-vm/asdf) version manager.
 
 ## Install
 

--- a/bin/download
+++ b/bin/download
@@ -9,8 +9,8 @@ plugin_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../lib/utils.bash
 source "${plugin_dir}/../lib/utils.bash"
 
-declare -r JQ_REPO="https://github.com/stedolan/jq.git"
-declare -r RELEASES_URL="https://api.github.com/repos/stedolan/jq/releases"
+declare -r JQ_REPO="https://github.com/jqlang/jq.git"
+declare -r RELEASES_URL="https://api.github.com/repos/jqlang/jq/releases"
 
 
 error_exit() {

--- a/bin/help.overview
+++ b/bin/help.overview
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-echo "asdf-jq is an asdf-vm plugin to install, download or compile jq, a command-line JSON processing tool from stedolan."
+echo "asdf-jq is an asdf-vm plugin to install, download or compile jq, a command-line JSON processing tool from jqlang."

--- a/bin/list-all
+++ b/bin/list-all
@@ -12,7 +12,7 @@ plugin_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../lib/utils.bash
 source "${plugin_dir}/../lib/utils.bash"
 
-readonly RELEASES_URL="https://api.github.com/repos/stedolan/jq/releases"
+readonly RELEASES_URL="https://api.github.com/repos/jqlang/jq/releases"
 
 # https://github.com/rbenv/ruby-build/blob/ac92ec0507fad718e7abcf13540641937ecfef3f/bin/ruby-build#L1201
 sort_versions() {


### PR DESCRIPTION
## What

Updated the repo references for upstream to `jqlang`.

## Why

`jq` repo has been moved.
Also resolves: https://github.com/AZMCode/asdf-jq/issues/8