### PR TITLE
[Bugfix] Fix arm64 install of jq

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![](https://github.com/AZMCode/asdf-jq/workflows/ci/badge.svg)
 
-[jq](https://stedolan.github.io/jq/) plugin for the [asdf](https://github.com/asdf-vm/asdf) version manager.
+[jq](https://jqlang.github.io/jq/) plugin for the [asdf](https://github.com/asdf-vm/asdf) version manager.
 
 ## Install
 

--- a/bin/download
+++ b/bin/download
@@ -31,6 +31,8 @@ get_arch(){
   declare arch="$(uname -m)"
   if [ "$arch" == 'x86_64' ]; then
     echo '64'
+  elif [ "$arch" == 'arm64' ]; then
+    echo '64'
   elif [ "$arch" == 'i386' ]; then
     echo '32'
   elif [ "$arch" == 'i686' ]; then
@@ -128,6 +130,7 @@ download() {
 
   if [ "$download_type" == "version" ]; then
     declare -r download_url="$(find_file_url "$download_version")"
+    printf "Downloading jq $download_version ($download_url)...\n"
     if [ -z "$download_url" ]; then
       error_exit "Malformed URL"
     fi
@@ -137,10 +140,12 @@ download() {
     rm -rf "$download_path"
     git init "$download_path"
     cd "$download_path"
+    printf "Installing jq $download_version from git source...\n"
     git remote add origin "$JQ_REPO"
     git fetch --depth=1 origin "$download_version"
     git reset --hard "$download_version"
   fi
+  printf "jq $download_version installed!\n"
 }
 
 

--- a/bin/download
+++ b/bin/download
@@ -9,8 +9,8 @@ plugin_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../lib/utils.bash
 source "${plugin_dir}/../lib/utils.bash"
 
-declare -r JQ_REPO="https://github.com/stedolan/jq.git"
-declare -r RELEASES_URL="https://api.github.com/repos/stedolan/jq/releases"
+declare -r JQ_REPO="https://github.com/jqlang/jq.git"
+declare -r RELEASES_URL="https://api.github.com/repos/jqlang/jq/releases"
 
 
 error_exit() {

--- a/bin/help.overview
+++ b/bin/help.overview
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-echo "asdf-jq is an asdf-vm plugin to install, download or compile jq, a command-line JSON processing tool from stedolan."
+echo "asdf-jq is an asdf-vm plugin to install, download or compile jq, a command-line JSON processing tool."

--- a/bin/list-all
+++ b/bin/list-all
@@ -12,7 +12,7 @@ plugin_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../lib/utils.bash
 source "${plugin_dir}/../lib/utils.bash"
 
-readonly RELEASES_URL="https://api.github.com/repos/stedolan/jq/releases"
+readonly RELEASES_URL="https://api.github.com/repos/jqlang/jq/releases"
 
 # https://github.com/rbenv/ruby-build/blob/ac92ec0507fad718e7abcf13540641937ecfef3f/bin/ruby-build#L1201
 sort_versions() {


### PR DESCRIPTION
Add `arm64` to the arch check, and include additional log output to tell the user which version is being installed.

```
$ asdf install jq 1.6
Downloading jq 1.6 (https://github.com/jqlang/jq/releases/download/jq-1.6/jq-osx-amd64)...
jq 1.6 installed!
```

Test Plan:

- [x] Run `asdf install jq 1.6` and verify that it is installed correctly on an M1 MacBook and the output appears as above.