### PR TITLE
[Bugfix] No compatible versions available (jq )

### DIFF
--- a/bin/download
+++ b/bin/download
@@ -45,9 +45,9 @@ get_assets_url() {
   declare install_version="$1"
 
   if [ -n "${GITHUB_API_TOKEN:+defined}" ]; then
-    declare releases_json="$(curl_wrapper -fsS "$RELEASES_URL" -H "Authorization: token $GITHUB_API_TOKEN")"
+    declare releases_json="$(curl_wrapper -LfsS "$RELEASES_URL" -H "Authorization: token $GITHUB_API_TOKEN")"
   else
-    declare releases_json="$(curl_wrapper -fsS "$RELEASES_URL")"
+    declare releases_json="$(curl_wrapper -LfsS "$RELEASES_URL")"
   fi
 
   declare -a asset_urls
@@ -74,9 +74,9 @@ find_all_asset_names() {
   fi
 
   if [ -n "${GITHUB_API_TOKEN:+defined}" ]; then
-    declare assets_json="$(curl_wrapper -fsS "$assets_url" -H "Authorization: token $GITHUB_API_TOKEN")"
+    declare assets_json="$(curl_wrapper -LfsS "$assets_url" -H "Authorization: token $GITHUB_API_TOKEN")"
   else
-    declare assets_json="$(curl_wrapper -fsS "$assets_url")"
+    declare assets_json="$(curl_wrapper -LfsS "$assets_url")"
   fi
   declare -a output=($(echo "$assets_json" | sed -n -E 's/[[:blank:]]*"browser_download_url":[[:blank:]]{0,2}"([^"]{8,})"/\1/p'))
   echo "${output[@]}"

--- a/bin/list-all
+++ b/bin/list-all
@@ -22,9 +22,9 @@ sort_versions() {
 
 list_versions() {
   if [ -n "${GITHUB_API_TOKEN:+defined}" ]; then
-    declare releases="$(curl_wrapper -fsS "$RELEASES_URL" -H "Authorization: token $GITHUB_API_TOKEN")"
+    declare releases="$(curl_wrapper -LfsS "$RELEASES_URL" -H "Authorization: token $GITHUB_API_TOKEN")"
   else
-    declare releases="$(curl_wrapper -fsS "$RELEASES_URL")"
+    declare releases="$(curl_wrapper -LfsS "$RELEASES_URL")"
   fi
   echo "$(echo "$releases" | grep -oE "tag_name\": *\".*\"," | sed 's/tag_name\": *\"//;s/\",//')"
 }


### PR DESCRIPTION
```bash
curl https://api.github.com/repos/stedolan/jq/releases -v
...
< location: https://api.github.com/repositories/5101141/releases
{
  "message": "Moved Permanently",
  "url": "https://api.github.com/repositories/5101141/releases",
  "documentation_url": "https://docs.github.com/v3/#http-redirects"
}
```

We need to follow 301 redirection to list available releases and download release (when install)